### PR TITLE
fix: ensure Google Cloud Project ID reflects in Settings UI

### DIFF
--- a/app/src/utils/configAPI.ts
+++ b/app/src/utils/configAPI.ts
@@ -62,6 +62,7 @@ export class Config {
       model: 'default',
       maxMessagesBeforeCompact: 25,
       geminiAuth: false,
+      googleCloudProjectId: undefined, // Google Cloud Project IDのデフォルト値
     };
   }
 
@@ -96,7 +97,11 @@ export class Config {
         return defaultSettings;
       }
       const json = await readTextFile(this.configFile);
-      return JSON.parse(json);
+      const parsedSettings = JSON.parse(json);
+      // デフォルト設定と読み込んだ設定をmerge (既存フィールドは上書き保持)
+      const defaultSettings = await this.buildDefaultSettings();
+      const finalSettings = { ...defaultSettings, ...parsedSettings };
+      return finalSettings;
     } catch (error: any) {
       console.error('Failed to load config:', error);
       // No local fallback available; try to ensure base dir and create default config file


### PR DESCRIPTION
Fixes issue #10 by ensuring the Google Cloud Project ID saved during auto-setup is properly reflected in the Settings UI for existing users.

🤖 Generated with [Claude Code](https://claude.ai/code)