### PR TITLE
fix: Require geminiPath configuration and remove unsafe fallback

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -15,6 +15,7 @@
         "@tauri-apps/plugin-opener": "^2",
         "@tauri-apps/plugin-os": "~2",
         "@tauri-apps/plugin-shell": "~2",
+        "@types/node": "^24.6.2",
         "@types/react-syntax-highlighter": "^15.5.13",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -1496,6 +1497,15 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
+    },
+    "node_modules/@types/node": {
+      "version": "24.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.6.2.tgz",
+      "integrity": "sha512-d2L25Y4j+W3ZlNAeMKcy7yDsK425ibcAOO2t7aPTz6gNMH0z2GThtwENCDc0d/Pw9wgyRqE5Px1wkV7naz8ang==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.13.0"
+      }
     },
     "node_modules/@types/react": {
       "version": "19.2.0",
@@ -3193,6 +3203,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz",
+      "integrity": "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==",
+      "license": "MIT"
     },
     "node_modules/unified": {
       "version": "11.0.5",

--- a/app/src/pages/Chat.css
+++ b/app/src/pages/Chat.css
@@ -1834,3 +1834,69 @@
     background-color: rgba(252, 211, 77, 0.1);
   }
 }
+
+/* Error Banner */
+.error-banner {
+  background-color: #fee2e2;
+  border: 1px solid #fca5a5;
+  border-radius: var(--radius-md);
+  padding: var(--spacing-md) var(--spacing-lg);
+  margin-bottom: var(--spacing-lg);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+[data-theme="dark"] .error-banner {
+  background-color: #451a1a;
+  border-color: #dc2626;
+}
+
+.error-message {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  color: #dc2626;
+  font-size: 14px;
+  line-height: 1.5;
+  flex: 1;
+}
+
+[data-theme="dark"] .error-message {
+  color: #fca5a5;
+}
+
+.error-icon {
+  font-size: 18px;
+  flex-shrink: 0;
+}
+
+.error-dismiss {
+  background: none;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+  color: #dc2626;
+  padding: 2px 6px;
+  border-radius: 4px;
+  transition: background-color 0.2s;
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+[data-theme="dark"] .error-dismiss {
+  color: #fca5a5;
+}
+
+.error-dismiss:hover {
+  background-color: rgba(220, 38, 38, 0.1);
+}
+
+[data-theme="dark"] .error-dismiss:hover {
+  background-color: rgba(252, 165, 165, 0.1);
+}

--- a/app/src/pages/Chat.tsx
+++ b/app/src/pages/Chat.tsx
@@ -114,6 +114,7 @@ export default function Chat({
 
   const [geminiPath, setGeminiPath] = useState<string | undefined>();
   const [recentlyCompletedSuggestion, setRecentlyCompletedSuggestion] = useState(false);
+  const [geminiPathError, setGeminiPathError] = useState<string>('');
 
   // Load geminiPath from config on workspace change
   useEffect(() => {
@@ -122,10 +123,18 @@ export default function Chat({
         const { Config } = await import('../utils/configAPI');
         const workspaceConfig = new Config(`${workspace.id}\\.geminiconfig`);
         const config = await workspaceConfig.loadConfig();
-        setGeminiPath(config?.geminiPath);
+        const loadedGeminiPath = config?.geminiPath;
+        setGeminiPath(loadedGeminiPath);
+
+        if (!loadedGeminiPath) {
+          setGeminiPathError('geminiPath が設定されていません。セットアップを実行して gemini.ps1 のパスを設定してください。');
+        } else {
+          setGeminiPathError('');
+        }
       } catch (error) {
         console.error('Failed to load geminiPath from config:', error);
         setGeminiPath(undefined);
+        setGeminiPathError('設定ファイルの読み込みに失敗しました。');
       }
     };
 
@@ -948,6 +957,20 @@ export default function Chat({
         </div>
 
         <div className="chat-main">
+          {geminiPathError && (
+            <div className="error-banner">
+              <div className="error-message">
+                <span className="error-icon">⚠️</span>
+                <span>{geminiPathError}</span>
+                <button
+                  className="error-dismiss"
+                  onClick={() => setGeminiPathError('')}
+                >
+                  ✕
+                </button>
+              </div>
+            </div>
+          )}
           <div className="messages-container">
             {(() => {
               return currentSession?.messages.length === 0 ? (

--- a/app/src/utils/geminiCUI.ts
+++ b/app/src/utils/geminiCUI.ts
@@ -197,14 +197,13 @@ export async function callGemini(
     internalLog(`Workspace path: ${workspacePath}`, log);
     //internalLog(`Options: ${JSON.stringify(options)}`, log);
     internalLog(`Google Cloud Project ID: ${googleCloudProjectId}`, log);
-    
 
-    // gemini is a PowerShell script located at the npm global installation path
+
+    // gemini is a PowerShell script located at the configured path
     let geminiPathFinal = geminiPath;
     if (!geminiPathFinal) {
-      // Fallback to hardcoded path if not provided
-      geminiPathFinal = `C:\\nvm4w\\nodejs\\gemini.ps1`;
-      internalLog(`No geminiPath provided, using fallback path: ${geminiPathFinal}`, log);
+      // Require geminiPath to be configured - no unsafe fallback to hardcoded paths
+      throw new Error('geminiPath is required but not configured. Please run setup to configure the gemini.ps1 path.');
     }
 
   internalLog(`Using gemini path: ${geminiPathFinal}`, log);


### PR DESCRIPTION
Addresses the PowerShell error when gemini.ps1 path is not configured properly.

- Remove hardcoded fallback to C:\\nvm4w\\nodejs\\gemini.ps1
- Require geminiPath to be properly configured before API calls
- Add error banner to guide users to run setup

Closes #19

🤗 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>